### PR TITLE
Refactor: 메인 페이지 같이 먹기 공고에 오늘 날짜만 나오도록 조건절 추가(#69)

### DIFF
--- a/src/app/api/together-posts/route.ts
+++ b/src/app/api/together-posts/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import response from "@/lib/http/response";
 import {
@@ -67,6 +67,10 @@ export async function GET(request: NextRequest) {
   const limit = Math.min(Math.max(Number(limitParam) || 20, 1), 100);
   const rid = searchParams.get("rid")?.trim();
 
+  // 오늘 0시 0분 0초 (로컬 기준) — 오늘 이후 작성된 공고만
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+
   const base = db
     .select({
       id: togetherPostTable.id,
@@ -92,13 +96,19 @@ export async function GET(request: NextRequest) {
         .where(
           and(
             eq(togetherPostTable.rid, rid),
-            eq(storeTable.isDeleted, false)
+            eq(storeTable.isDeleted, false),
+            gte(togetherPostTable.createdAt, startOfToday)
           )
         )
         .orderBy(desc(togetherPostTable.createdAt))
         .limit(limit)
     : await base
-        .where(eq(storeTable.isDeleted, false))
+        .where(
+          and(
+            eq(storeTable.isDeleted, false),
+            gte(togetherPostTable.createdAt, startOfToday)
+          )
+        )
         .orderBy(desc(togetherPostTable.createdAt))
         .limit(limit);
 


### PR DESCRIPTION
# PR 템플릿


## #️⃣ 연관된 이슈

> #69 



## 체크리스트!
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?



## 📝작업 내용

> 홈페이지에 있는 같이 먹기 공고들이 오늘 날짜로 등록된 공고들만 올라오도록 수정



## 💬피드백을 받고 싶은 부분 (선택)



### PR 특이 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 투게더 게시물이 오늘 생성된 항목만 표시하도록 일일 필터링 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->